### PR TITLE
[feature]GameMode-MatchCancel

### DIFF
--- a/Source/TreasureHunter/Game/THGameModeBase.h
+++ b/Source/TreasureHunter/Game/THGameModeBase.h
@@ -56,6 +56,10 @@ private:
 
 	bool CheckEnoughPlayer();
 
+	void StartMatchTimer();
+
+	void StopMatch(bool Rematch);
+
 private:
 	FGameplayTag GameModeFlow;
 
@@ -64,6 +68,10 @@ private:
 	int32 MaxMatchPlayerNum;
 
 	int32 CurMatchWaitPlayerNum;	
+
+	FTimerHandle MatchTimerHandle;
+
+	float MatchWaitTime;
 
 public:
 	TArray<FPlayerData> LoginPlayerData;


### PR DESCRIPTION
1.매칭 시작시 MatchTimer가 작동하도록 구현
2.일정 MatchTime 이상 매치가 안될 때 MatchFail되는 기능 구현
3.Match에서 한명 이상의 플레이어가 게임을 종료했을 때 Main으로 돌아간 후 Rematch가 시작되도록 구현 => 현재 Rematch가 되긴하나. icon은 뜨지 않는 문제있음
4.MatchWait중 게임 종료시 Match대기열에서 제거하는 기능 구현
5.Match가 잡혔을 때 Match된 인원을 제외한 다른 Wait Player들은 Match Fail되도록 구현
6.ClientCancelMatch는 주석처리 해놓음.

+테스트 하다가 발견한 상황: 서버가 시작되면 GameMode의 Phase가 Wait으로 초기화 되는데 Client가 게임 입장시 ShowMainMenu()를 호출하여 ShowMainMenu()가 두번 호출되는 상황이 존재함.
