### PR TITLE
[feature] 등반 높이기반 UI 업데이트 및 순위 변동 UI 로직 구현

### DIFF
--- a/Content/TreasureHunter/UI/HUD_THPlayer.uasset
+++ b/Content/TreasureHunter/UI/HUD_THPlayer.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bc2cb213a01dcf2752e7ae0e5477511e00c989663490098183e686bc32582eb6
-size 81700
+oid sha256:c72552e0fa527ec7f099dd3b6c8aebc8c906b94f6972eedba6bd645a8893d462
+size 193285

--- a/Content/TreasureHunter/UI/Icons/19_point.uasset
+++ b/Content/TreasureHunter/UI/Icons/19_point.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fd37a2ed75d61872d5e302ccec3b696972767574a24e363c9d05c6f1150a98c5
+size 19370

--- a/Source/TreasureHunter/Player/THPlayerController.cpp
+++ b/Source/TreasureHunter/Player/THPlayerController.cpp
@@ -287,3 +287,25 @@ void ATHPlayerController::Client_ShowTargetOverlay_Implementation(FName ItemRow)
 	}
 }
 #pragma endregion
+
+#pragma region Climb&Rank
+
+void ATHPlayerController::Client_UpdateClimb_Implementation(uint8 QSelf, uint8 QOppo)
+{
+	const float SelfP = static_cast<float>(QSelf) / 255.f;
+	const float OppoP = static_cast<float>(QOppo) / 255.f;
+
+	if (PlayerHUD)
+	{
+		PlayerHUD->SetClimbUIUpdate(SelfP, OppoP);
+	}
+}
+
+void ATHPlayerController::Client_UpdateWinner_Implementation(bool bBunnyWinning)
+{
+	if (PlayerHUD)
+	{
+		PlayerHUD->SetRankUIUpdate(bBunnyWinning);
+	}
+}
+#pragma endregion

--- a/Source/TreasureHunter/Player/THPlayerController.h
+++ b/Source/TreasureHunter/Player/THPlayerController.h
@@ -73,4 +73,12 @@ private:
 	UFUNCTION(Client, Reliable)
 	void Client_ShowTargetOverlay(FName ItemRow);
 #pragma endregion
+
+#pragma region Climb&Rank
+public:
+	UFUNCTION(Client, Unreliable) // Activate when players start climbing
+	void Client_UpdateClimb(uint8 QSelf, uint8 QOppo);
+	UFUNCTION(Client, Reliable) // Always Active
+	void Client_UpdateWinner(bool bBunnyWinning);
+#pragma endregion
 };

--- a/Source/TreasureHunter/UI/THPlayerHUDWidget.h
+++ b/Source/TreasureHunter/UI/THPlayerHUDWidget.h
@@ -10,6 +10,7 @@ class UImage;
 class UProgressBar;
 class UHorizontalBox;
 class USizeBox;
+class UWidgetAnimation;
 class UAbilitySystemComponent;
 class UTHAttributeSet;
 class UUserWidget;
@@ -191,16 +192,36 @@ private:
 	void StopDurationTimer();
 #pragma endregion
 
-
-
+#pragma region Climbing&Rank
 protected:
 	UPROPERTY(BlueprintReadOnly, Category = "HUD", meta = (BindWidget))
 	UProgressBar* ClimbingBar;
+	UPROPERTY(BlueprintReadOnly, Category = "HUD", meta = (BindWidget))
+	UImage* OppositeClimbPoint;
+	UPROPERTY(Transient, BlueprintReadWrite, meta = (BindWidgetAnimOptional))
+	UWidgetAnimation* RabbitUpAnim;
 
-	UPROPERTY(meta = (BindWidget))
-	UImage* SecondPlayerIMG;
-	UPROPERTY(meta = (BindWidget))
-	UImage* FirstPlayerIMG;
+private:
+	bool bHasBunnyBeenWinning;
+	bool  bOppoBaseYInit = false;
+	float OppoBaseY;
+	float OppoTravelDeltaY;
+
+	FTimerHandle ClimbSmoothTimer;
+	float TargetSelfP;
+	float TargetOppoP;
+	float DisplayedSelfP, DisplayedOppoP;
+
+public:
+	void SetRankUIUpdate(bool bBunnyWinning);
+	void SetClimbUIUpdate(float SlefP, float OppoP);
+
+private:
+	void SetClimbSelfUpdate(float SelfP);
+	void SetClimbOppoUpdate(float OppoP);
+
+	void ClimbSmoothing();
+#pragma endregion
 
 private:
 	UPROPERTY()
@@ -214,5 +235,4 @@ private:
 	FDelegateHandle WalkSpeedChangedHandle;
 	FDelegateHandle SprintSpeedChangedHandle;
 	FDelegateHandle SprintingTagHandle;
-
 };


### PR DESCRIPTION
- HUD 위젯에서 등반 높이 업데이트 디자인 수정 (상대편 등반 높이 알려주는 포인터 추가)
- PlayerController에서 Client RPC로 UI 업데이트 (UpdateClimb은 등반 높이 UI 변경용 RPC, UpdateWinner은 순위 변경 UI용 RPC) 로직 구현
- HUD Widget에서 애니메이션 기반으로 순위 변경하는 로직 구현
- HUD Widget에서 Timer기반으로 ProgressBar의 Percent 수정하고, 이미지의 높낮이 변경하는 로직 구현 (Animated)