### PR TITLE
[feature] 게임오버 위젯에 기능 추가

### DIFF
--- a/Config/DefaultGameplayTags.ini
+++ b/Config/DefaultGameplayTags.ini
@@ -42,6 +42,13 @@ NetIndexFirstBitSegment=16
 +GameplayTagList=(Tag="Game.Phase.Play",    DevComment="GamePlaying")
 +GameplayTagList=(Tag="Game.Phase.Finish",  DevComment="GameFinish")
 
+; ----- Game Phase: AfterGameOver -----
++GameplayTagList=(Tag="Game.Rematch.Pending",    DevComment="Pending")
++GameplayTagList=(Tag="Game.Rematch.AcceptedBoth",   DevComment="AcceptRematch")
++GameplayTagList=(Tag="Game.Rematch.Declined", DevComment="DeclineRematch")
++GameplayTagList=(Tag="Game.Rematch.OpponentLeft",    DevComment="OpponentLeft")
++GameplayTagList=(Tag="Game.Rematch.Timeout",  DevComment="Timeout")
+
 ; ----- Player State -----
 +GameplayTagList=(Tag="Player.Ready",            DevComment="PlayerReady")
 +GameplayTagList=(Tag="Player.Character.First",  DevComment="BunnySelected")

--- a/Content/TreasureHunter/UI/Icons/19_point.uasset
+++ b/Content/TreasureHunter/UI/Icons/19_point.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fd37a2ed75d61872d5e302ccec3b696972767574a24e363c9d05c6f1150a98c5
-size 19370

--- a/Content/TreasureHunter/UI/Icons/20_point.uasset
+++ b/Content/TreasureHunter/UI/Icons/20_point.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4ebb4263de72bc4e81caaae27a22f3a4bc30121e87c45ef774e09766df034b94
+size 19465

--- a/Content/TreasureHunter/UI/Icons/21_Modal.uasset
+++ b/Content/TreasureHunter/UI/Icons/21_Modal.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3065246f6a55932a2d517ff070a7c7df049d256f7b72866266fec97ae052b3ed
+size 69511

--- a/Content/TreasureHunter/UI/WBP_GameOver.uasset
+++ b/Content/TreasureHunter/UI/WBP_GameOver.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:93ec5dc45f0c7dabeb166f653f81d2ef347a0d168404f14b44ffc1e628a38815
-size 93911
+oid sha256:495ad5e57cf3436e9e78cd9e9bc66b7b37bce79269d7bb07a53258b2d559834d
+size 128579

--- a/Source/TreasureHunter/Game/GameFlowTags.cpp
+++ b/Source/TreasureHunter/Game/GameFlowTags.cpp
@@ -33,6 +33,13 @@ UE_DEFINE_GAMEPLAY_TAG_COMMENT(TAG_Game_Phase_Loading, "Game.Phase.Loading", "Le
 UE_DEFINE_GAMEPLAY_TAG_COMMENT(TAG_Game_Phase_Play, "Game.Phase.Play", "GamePlaying");
 UE_DEFINE_GAMEPLAY_TAG_COMMENT(TAG_Game_Phase_Finish, "Game.Phase.Finish", "GameFinish");
 
+// ----- Game Phase: AfterGameOver -----
+UE_DEFINE_GAMEPLAY_TAG_COMMENT(TAG_Game_Rematch_Pending, "Game.Rematch.Pending", "Pending");
+UE_DEFINE_GAMEPLAY_TAG_COMMENT(TAG_Game_Rematch_AcceptedBoth, "Game.Rematch.AcceptedBoth", "AcceptRematch");
+UE_DEFINE_GAMEPLAY_TAG_COMMENT(TAG_Game_Rematch_Declined, "Game.Rematch.Declined", "DeclineRematch");
+UE_DEFINE_GAMEPLAY_TAG_COMMENT(TAG_Game_Rematch_OpponentLeft, "Game.Rematch.OpponentLeft", "OpponentLeft");
+UE_DEFINE_GAMEPLAY_TAG_COMMENT(TAG_Game_Rematch_Timeout, "Game.Rematch.Timeout", "Timeout");
+
 // ----- Player State -----
 UE_DEFINE_GAMEPLAY_TAG_COMMENT(TAG_Player_Ready, "Player.Ready", "Player Ready");
 UE_DEFINE_GAMEPLAY_TAG_COMMENT(TAG_Player_Character_First, "Player.Character.First", "Bunny Selected");

--- a/Source/TreasureHunter/Game/GameFlowTags.h
+++ b/Source/TreasureHunter/Game/GameFlowTags.h
@@ -34,6 +34,13 @@ UE_DECLARE_GAMEPLAY_TAG_EXTERN(TAG_Game_Phase_Loading);
 UE_DECLARE_GAMEPLAY_TAG_EXTERN(TAG_Game_Phase_Play);
 UE_DECLARE_GAMEPLAY_TAG_EXTERN(TAG_Game_Phase_Finish);
 
+// ----- Game Phase: AfterGameOver -----
+UE_DECLARE_GAMEPLAY_TAG_EXTERN(TAG_Game_Rematch_Pending);
+UE_DECLARE_GAMEPLAY_TAG_EXTERN(TAG_Game_Rematch_AcceptedBoth);
+UE_DECLARE_GAMEPLAY_TAG_EXTERN(TAG_Game_Rematch_Declined);
+UE_DECLARE_GAMEPLAY_TAG_EXTERN(TAG_Game_Rematch_OpponentLeft);
+UE_DECLARE_GAMEPLAY_TAG_EXTERN(TAG_Game_Rematch_Timeout);
+
 // ----- Player State -----
 UE_DECLARE_GAMEPLAY_TAG_EXTERN(TAG_Player_Ready);
 UE_DECLARE_GAMEPLAY_TAG_EXTERN(TAG_Player_Character_First);

--- a/Source/TreasureHunter/Game/THGameStateBase.cpp
+++ b/Source/TreasureHunter/Game/THGameStateBase.cpp
@@ -32,6 +32,12 @@ void ATHGameStateBase::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& Out
 	DOREPLIFETIME(ATHGameStateBase, WinnerTag);
 	DOREPLIFETIME(ATHGameStateBase, SlotOwners);
 	DOREPLIFETIME(ATHGameStateBase, bSlotsLockedIn);
+
+	DOREPLIFETIME(ATHGameStateBase, RematchTag);
+	DOREPLIFETIME(ATHGameStateBase, RematchRequester);
+	DOREPLIFETIME(ATHGameStateBase, RematchResponder);
+	DOREPLIFETIME(ATHGameStateBase, RematchAcceptMask);
+	DOREPLIFETIME(ATHGameStateBase, RematchExpireAt);
 }
 
 #pragma region Phase
@@ -140,5 +146,23 @@ void ATHGameStateBase::OnRep_SlotOwners()
 void ATHGameStateBase::OnRep_SlotsLockedIn()
 {
 	OnSlotsUpdated.Broadcast();
+}
+#pragma endregion
+
+#pragma region Rematch
+void ATHGameStateBase::OnRep_RematchTag()
+{
+	OnRematchChanged.Broadcast(RematchTag);
+}
+
+void ATHGameStateBase::ResetRematchState() // Initialize when Phase Finish
+{
+	RematchTag = FGameplayTag();
+	RematchRequester = nullptr;
+	RematchResponder = nullptr;
+	RematchAcceptMask = 0;
+	RematchExpireAt = 0.f;
+	OnRep_RematchTag();
+	ForceNetUpdate();
 }
 #pragma endregion

--- a/Source/TreasureHunter/Game/THGameStateBase.h
+++ b/Source/TreasureHunter/Game/THGameStateBase.h
@@ -7,6 +7,7 @@
 #include "THGameStateBase.generated.h"
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnPhaseChangedSig, FGameplayTag, NewPhase);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnRematchChangedSig, FGameplayTag, NewTag);
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnSlotsUpdatedSig);
 
@@ -81,5 +82,47 @@ public:
 
 	void ResetSlots();
 
+#pragma endregion
+
+#pragma region Rematch
+public:
+	UFUNCTION()
+	void OnRep_RematchTag();
+
+	UFUNCTION(BlueprintCallable, Category = "Rematch")
+	APlayerState* GetRematchRequester() const { return RematchRequester; }
+
+	UFUNCTION(BlueprintCallable, Category = "Rematch")
+	APlayerState* GetRematchResponder() const { return RematchResponder; }
+
+	UFUNCTION(BlueprintCallable, Category = "Rematch")
+	uint8 GetRematchAcceptMask() const { return RematchAcceptMask; }
+
+	UFUNCTION(BlueprintCallable, Category = "Rematch")
+	float GetRematchExpireAt() const { return RematchExpireAt; }
+
+	UFUNCTION(BlueprintCallable, Category = "Rematch")
+	void ResetRematchState();
+
+public:
+	UPROPERTY(BlueprintAssignable)
+	FOnRematchChangedSig OnRematchChanged;
+
+protected:
+	UPROPERTY(ReplicatedUsing = OnRep_RematchTag, BlueprintReadOnly, Category = "Rematch")
+	FGameplayTag RematchTag;
+
+private:
+	UPROPERTY(Replicated)
+	TObjectPtr<APlayerState> RematchRequester = nullptr;
+
+	UPROPERTY(Replicated)
+	TObjectPtr<APlayerState> RematchResponder = nullptr;
+
+	UPROPERTY(Replicated)
+	uint8 RematchAcceptMask = 0; // 0=Requester, 1=Responder
+
+	UPROPERTY(Replicated)
+	float RematchExpireAt = 0.f;
 #pragma endregion
 };

--- a/Source/TreasureHunter/Player/THPlayerController.h
+++ b/Source/TreasureHunter/Player/THPlayerController.h
@@ -81,4 +81,20 @@ public:
 	UFUNCTION(Client, Reliable) // Always Active
 	void Client_UpdateWinner(bool bBunnyWinning);
 #pragma endregion
+
+#pragma region Rematch
+public:
+	UFUNCTION(Server, Reliable)
+	void Server_RequestRematch();
+
+	UFUNCTION(Server, Reliable)
+	void Server_RespondRematch(bool bAccept);
+
+	UFUNCTION(Server, Reliable)
+	void Server_LeaveToMainMenu();
+
+private:
+	UFUNCTION()
+	void HandleRematchChanged(FGameplayTag NewTag);
+#pragma endregion
 };

--- a/Source/TreasureHunter/UI/THGameOverWidget.cpp
+++ b/Source/TreasureHunter/UI/THGameOverWidget.cpp
@@ -3,6 +3,8 @@
 
 #include "UI/THGameOverWidget.h"
 #include "Components/Button.h"
+#include "Components/TextBlock.h"
+#include "Components/Overlay.h"
 #include "Kismet/GameplayStatics.h"
 #include "Player/THPlayerController.h"
 #include "Game/GameFlowTags.h"
@@ -10,31 +12,25 @@
 void UTHGameOverWidget::NativeConstruct()
 {
 	Super::NativeConstruct();
-	if (RestartButton)
-	{
-		RestartButton->OnClicked.AddDynamic(this, &ThisClass::HandleRestartClicked);
-	}
-	if (MainMenuButton)
-	{
-		MainMenuButton->OnClicked.AddDynamic(this, &ThisClass::HandleMainMenuClicked);
-	}
+	if (RestartButton) RestartButton->OnClicked.AddDynamic(this, &ThisClass::HandleRestartClicked);
+	if (MainMenuButton) MainMenuButton->OnClicked.AddDynamic(this, &ThisClass::HandleMainMenuClicked);
 
-	if (ButtonAppearingAnim)
-	{
-		PlayAnimation(ButtonAppearingAnim);
-	}
+	if (ButtonAppearingAnim) PlayAnimation(ButtonAppearingAnim);
+
+	if (DeclineText) DeclineText->SetVisibility(ESlateVisibility::Hidden);
+	if (RematchModal) RematchModal->SetVisibility(ESlateVisibility::Collapsed);
+
+	if (AcceptButton) AcceptButton->OnClicked.AddDynamic(this, &ThisClass::HandleAcceptClicked);
+	if (DeclineButton) DeclineButton->OnClicked.AddDynamic(this, &ThisClass::HandleDeclineClicked);
 }
 
 void UTHGameOverWidget::NativeDestruct()
 {
-	if (RestartButton)
-	{
-		RestartButton->OnClicked.RemoveAll(this);
-	}
-	if (MainMenuButton)
-	{
-		MainMenuButton->OnClicked.RemoveAll(this);
-	}
+	if (RestartButton)  RestartButton->OnClicked.RemoveDynamic(this, &ThisClass::HandleRestartClicked);
+	if (MainMenuButton) MainMenuButton->OnClicked.RemoveDynamic(this, &ThisClass::HandleMainMenuClicked);
+
+	if (AcceptButton)   AcceptButton->OnClicked.RemoveDynamic(this, &ThisClass::HandleAcceptClicked);
+	if (DeclineButton)  DeclineButton->OnClicked.RemoveDynamic(this, &ThisClass::HandleDeclineClicked);
 	Super::NativeDestruct();
 }
 
@@ -42,12 +38,67 @@ void UTHGameOverWidget::HandleRestartClicked()
 {
 	if (auto* PC = GetOwningPlayer<ATHPlayerController>())
 	{
-		// Request Server to reload the same level
-		return;
+		PC->Server_RequestRematch();
 	}
 }
 
 void UTHGameOverWidget::HandleMainMenuClicked()
 {
-	// Load Main Menu Level using soft object ptr 
+	if (auto* PC = GetOwningPlayer<ATHPlayerController>())
+	{
+		PC->Server_LeaveToMainMenu();
+	}
+}
+
+void UTHGameOverWidget::HandleAcceptClicked()
+{
+	if (auto* PC = GetOwningPlayer<ATHPlayerController>())
+	{
+		PC->Server_RespondRematch(true);
+	}
+}
+
+void UTHGameOverWidget::HandleDeclineClicked()
+{
+	if (auto* PC = GetOwningPlayer<ATHPlayerController>())
+	{
+		PC->Server_RespondRematch(false);
+	}
+}
+
+void UTHGameOverWidget::SetRestartEnabled(bool bEnabled)
+{
+	if (RestartButton) RestartButton->SetIsEnabled(bEnabled);
+}
+
+void UTHGameOverWidget::ShowDeclineText(const FText& InText)
+{
+	if (DeclineText)
+	{
+		DeclineText->SetText(InText);
+		DeclineText->SetVisibility(ESlateVisibility::Visible);
+	}
+}
+
+void UTHGameOverWidget::ShowWaitingForOpponent()
+{
+	ShowDeclineText(FText::FromString(TEXT("Waiting for the other player¡¦")));
+}
+
+void UTHGameOverWidget::ShowRematchModal()
+{
+	if (RematchModal)
+	{
+		RematchModal->SetVisibility(ESlateVisibility::Visible);
+		PlayAnimation(LoadingAnim, 0.0f, 0, EUMGSequencePlayMode::Forward, 1.0f, false);
+	}
+}
+
+void UTHGameOverWidget::HideRematchModal()
+{
+	if (RematchModal)
+	{
+		RematchModal->SetVisibility(ESlateVisibility::Collapsed);
+		StopAnimation(LoadingAnim);
+	}
 }

--- a/Source/TreasureHunter/UI/THGameOverWidget.h
+++ b/Source/TreasureHunter/UI/THGameOverWidget.h
@@ -8,7 +8,8 @@
 class UButton;
 class UImage;
 class UWidgetAnimation;
-
+class UOverlay;
+class UTextBlock;
 
 UCLASS()
 class TREASUREHUNTER_API UTHGameOverWidget : public UUserWidget
@@ -24,6 +25,18 @@ private:
 	UFUNCTION()
 	void HandleMainMenuClicked();
 
+	UFUNCTION()
+	void HandleAcceptClicked();
+	UFUNCTION()
+	void HandleDeclineClicked();
+
+public:
+	void SetRestartEnabled(bool bEnabled);
+	void ShowDeclineText(const FText& InText);
+	void ShowWaitingForOpponent();
+	void ShowRematchModal();
+	void HideRematchModal();
+
 protected:
 	UPROPERTY(meta = (BindWidget))
 	UButton* RestartButton;
@@ -35,4 +48,17 @@ protected:
 
 	UPROPERTY(Transient, meta = (BindWidgetAnim))
 	UWidgetAnimation* ButtonAppearingAnim;
+	UPROPERTY(Transient, meta = (BindWidgetAnim))
+	UWidgetAnimation* LoadingAnim;
+
+	UPROPERTY(meta = (BindWidget))
+	UOverlay* RematchModal;
+
+	UPROPERTY(meta = (BindWidget))
+	UButton* AcceptButton;
+	UPROPERTY(meta = (BindWidget))
+	UButton* DeclineButton;
+
+	UPROPERTY(meta = (BindWidget))
+	UTextBlock* DeclineText;
 };


### PR DESCRIPTION
- GameOver 시에 Phase 추가
- 위젯에 Modal 추가
- GameState에 Requester (rematch 신청한 사람) Responder (상대) 넣고 Rematch 대기 시간 (RematchExpireAt) 추가
- Rematch 태그가 변경되었을 때 컨트롤러 측에서, 게임오버 UI 변경 로직 처리
- 게임오버 UI 구현 추가