### PR TITLE
정확도 향상을 위한 클라이밍 및 맨틀링 트레이스 로직 리팩터링

### DIFF
--- a/Source/TreasureHunter/ParkourComponent/THClimbComponent.h
+++ b/Source/TreasureHunter/ParkourComponent/THClimbComponent.h
@@ -42,6 +42,12 @@ protected:
 	UPROPERTY(EditDefaultsOnly, Category = "Trace")
 	float ForwardTraceDistance = 50.f;
 
+	UPROPERTY(EditDefaultsOnly, Category = "Trace", meta = (DisplayName = "Climb Detection Capsule Radius"))
+	float ClimbCapsuleTraceRadius = 40.f;
+
+	UPROPERTY(EditDefaultsOnly, Category = "Trace", meta = (DisplayName = "Climb Detection Capsule Half Height"))
+	float ClimbCapsuleTraceHalfHeight = 70.f;
+
 	UPROPERTY(EditDefaultsOnly, Category = "Trace")
 	float LedgeTraceStartHeight = 150.f;
 

--- a/Source/TreasureHunter/ParkourComponent/THParkourComponent.cpp
+++ b/Source/TreasureHunter/ParkourComponent/THParkourComponent.cpp
@@ -23,7 +23,7 @@ UTHParkourComponent::UTHParkourComponent()
 void UTHParkourComponent::BeginPlay()
 {
 	Super::BeginPlay();
-	
+
 	OwnerCharacter = Cast<ACharacter>(GetOwner());
 	if (OwnerCharacter)
 	{
@@ -43,13 +43,49 @@ bool UTHParkourComponent::TraceForWall(FHitResult& OutFrontHit) const
 
 	const FVector FrontTraceStart = ActorLocation + FVector(0, 0, 50.f);
 	const FVector FrontTraceEnd = FrontTraceStart + ActorForward * MantleReachDistance;
-	const float FrontTraceRadius = CapsuleRadius - 2.f;
 
-	UKismetSystemLibrary::SphereTraceSingle(this, FrontTraceStart, FrontTraceEnd, FrontTraceRadius, UEngineTypes::ConvertToTraceType(ECC_WorldStatic), false, ActorsToIgnore, DrawDebugType, OutFrontHit, true);
+	TArray<FHitResult> OutHits;
+	UKismetSystemLibrary::SphereTraceMulti(
+		this,
+		FrontTraceStart,
+		FrontTraceEnd,
+		CapsuleRadius - 2.f,
+		UEngineTypes::ConvertToTraceType(ECC_WorldStatic),
+		false,
+		ActorsToIgnore,
+		DrawDebugType,
+		OutHits,
+		true
+	);
 
-	const bool bIsValidWall = OutFrontHit.bBlockingHit && FMath::Abs(OutFrontHit.ImpactNormal.Z) < 0.707f;
-	
-	return bIsValidWall;
+	if (OutHits.IsEmpty())
+	{
+		return false;
+	}
+
+	FHitResult BestHit;
+	float BestHitDot = -1.f;
+
+	for (const FHitResult& Hit : OutHits)
+	{
+		if (Hit.bBlockingHit && FMath::Abs(Hit.ImpactNormal.Z) < 0.707f)
+		{
+			float DotProduct = FVector::DotProduct(ActorForward, -Hit.ImpactNormal);
+			if (DotProduct > BestHitDot)
+			{
+				BestHitDot = DotProduct;
+				BestHit = Hit;
+			}
+		}
+	}
+
+	if (BestHit.bBlockingHit)
+	{
+		OutFrontHit = BestHit;
+		return true;
+	}
+
+	return false;
 }
 
 bool UTHParkourComponent::TraceForLedge(const FHitResult& FrontHit, FHitResult& OutSurfaceHit) const
@@ -59,20 +95,18 @@ bool UTHParkourComponent::TraceForLedge(const FHitResult& FrontHit, FHitResult& 
 	const TArray<AActor*> ActorsToIgnore = { OwnerCharacter };
 
 	const FVector ActorLocation = OwnerCharacter->GetActorLocation();
+	const FVector ActorForward = OwnerCharacter->GetActorForwardVector();
+	const float CapsuleRadius = OwnerCharacter->GetCapsuleComponent()->GetScaledCapsuleRadius();
 
-	const FVector WallNormal = FrontHit.ImpactNormal;
-	const FVector Offset = WallNormal * 5.f;
-
-	const FVector DownwardTraceStart = FVector(FrontHit.ImpactPoint.X, FrontHit.ImpactPoint.Y, ActorLocation.Z + MaxMantleHeight) + Offset;
-	const FVector DownwardTraceEnd = FVector(FrontHit.ImpactPoint.X, FrontHit.ImpactPoint.Y, ActorLocation.Z) + Offset;
-	
-	const float TraceRadius = 10.f;
+	const FVector TraceStartXY = ActorLocation + (ActorForward * (CapsuleRadius + 20.f));
+	const FVector DownwardTraceStart = FVector(TraceStartXY.X, TraceStartXY.Y, ActorLocation.Z + MaxMantleHeight);
+	const FVector DownwardTraceEnd = FVector(DownwardTraceStart.X, DownwardTraceStart.Y, ActorLocation.Z);
 
 	UKismetSystemLibrary::SphereTraceSingle(
 		this,
 		DownwardTraceStart,
 		DownwardTraceEnd,
-		TraceRadius,
+		15.f,
 		UEngineTypes::ConvertToTraceType(ECC_WorldStatic),
 		false,
 		ActorsToIgnore,
@@ -82,13 +116,12 @@ bool UTHParkourComponent::TraceForLedge(const FHitResult& FrontHit, FHitResult& 
 	);
 	
 	const float MantleHeight = OutSurfaceHit.ImpactPoint.Z - ActorLocation.Z;
-
 	const bool bIsSurfaceWalkable = OutSurfaceHit.ImpactNormal.Z > 0.7f;
 
 	return OutSurfaceHit.bBlockingHit && (MantleHeight >= MinMantleHeight) && bIsSurfaceWalkable;
 }
 
-bool UTHParkourComponent::IsLandingSpaceClear(const FVector& LandingLocation, const FRotator& TargetRotation) const // 수정된 함수
+bool UTHParkourComponent::IsLandingSpaceClear(const FVector& LandingCapsuleCenter) const
 {
 	const bool bDrawDebug = CVarDebugMantle.GetValueOnGameThread() > 0;
 	const EDrawDebugTrace::Type DrawDebugType = bDrawDebug ? EDrawDebugTrace::ForDuration : EDrawDebugTrace::None;
@@ -97,26 +130,30 @@ bool UTHParkourComponent::IsLandingSpaceClear(const FVector& LandingLocation, co
 	const float CapsuleHalfHeight = OwnerCharacter->GetCapsuleComponent()->GetScaledCapsuleHalfHeight();
 	const float CapsuleRadius = OwnerCharacter->GetCapsuleComponent()->GetScaledCapsuleRadius();
 
-	const FVector BoxHalfSize(CapsuleRadius, CapsuleRadius, CapsuleHalfHeight);
-	FHitResult BoxHit;
-
-	const bool bIsSpaceBlocked = UKismetSystemLibrary::BoxTraceSingle(this, 
-		LandingLocation,
-		LandingLocation, 
-		BoxHalfSize, 
-		TargetRotation, 
-		UEngineTypes::ConvertToTraceType(ECC_WorldStatic), 
-		false, 
-		ActorsToIgnore, 
-		DrawDebugType, 
-		BoxHit, 
-		true);
+	FHitResult CapsuleHit;
+	const bool bIsSpaceBlocked = UKismetSystemLibrary::CapsuleTraceSingle(
+		this,
+		LandingCapsuleCenter,
+		LandingCapsuleCenter,
+		CapsuleRadius,
+		CapsuleHalfHeight,
+		UEngineTypes::ConvertToTraceType(ECC_WorldStatic),
+		false,
+		ActorsToIgnore,
+		DrawDebugType,
+		CapsuleHit,
+		true
+	);
 
 	return !bIsSpaceBlocked;
 }
 
 bool UTHParkourComponent::CheckMantle(FMantleInfo& OutMantleInfo) const
 {
+	const bool bDrawDebug = CVarDebugMantle.GetValueOnGameThread() > 0;
+	const EDrawDebugTrace::Type DrawDebugType = bDrawDebug ? EDrawDebugTrace::ForDuration : EDrawDebugTrace::None;
+	const TArray<AActor*> ActorsToIgnore = { OwnerCharacter };
+
 	if (!IsValid(OwnerCharacter) || !IsValid(OwnerMovementComponent))
 	{
 		return false;
@@ -128,33 +165,59 @@ bool UTHParkourComponent::CheckMantle(FMantleInfo& OutMantleInfo) const
 		return false;
 	}
 	
+	const FVector LedgeTopLocation = SurfaceHit.ImpactPoint;
+	const float CapsuleHalfHeight = OwnerCharacter->GetCapsuleComponent()->GetScaledCapsuleHalfHeight();
+	const float CapsuleRadius = OwnerCharacter->GetCapsuleComponent()->GetScaledCapsuleRadius();
+	
 	FVector MantleDirection = OwnerCharacter->GetActorForwardVector();
 	MantleDirection.Z = 0.f;
 	MantleDirection.Normalize();
+
+	FVector DesiredLandingXY = LedgeTopLocation + (MantleDirection * (CapsuleRadius + MantleForwardOffset));
 	
-	const FRotator TargetRotation = MantleDirection.Rotation();
+	FVector TraceStart = FVector(DesiredLandingXY.X, DesiredLandingXY.Y, LedgeTopLocation.Z + MaxMantleHeight);
+	FVector TraceEnd = FVector(DesiredLandingXY.X, DesiredLandingXY.Y, LedgeTopLocation.Z - CapsuleHalfHeight * 2.f);
 
-	const float CapsuleHalfHeight = OwnerCharacter->GetCapsuleComponent()->GetScaledCapsuleHalfHeight();
-	const float CapsuleRadius = OwnerCharacter->GetCapsuleComponent()->GetScaledCapsuleRadius();
+	FHitResult GroundHit;
+	UKismetSystemLibrary::SphereTraceSingle(
+		this,
+		TraceStart,
+		TraceEnd,
+		10.f,
+		UEngineTypes::ConvertToTraceType(ECC_WorldStatic),
+		false,
+		ActorsToIgnore,
+		DrawDebugType,
+		GroundHit,
+		true
+	);
 
-	const FVector LedgeTopLocation = SurfaceHit.ImpactPoint;
-	
-	FVector FinalLandingRootLocation = LedgeTopLocation + (MantleDirection * (CapsuleRadius + MantleForwardOffset));
-	FinalLandingRootLocation.Z += FinalLandingHeightOffset;
-
-	const FVector LandingCapsuleCenter = FinalLandingRootLocation + FVector(0, 0, CapsuleHalfHeight);
-
-	if (!IsLandingSpaceClear(LandingCapsuleCenter, TargetRotation))
+	if (!GroundHit.bBlockingHit || GroundHit.ImpactNormal.Z < 0.7f)
 	{
 		return false;
 	}
 
-	CalculateWarpTargets(FrontHit, SurfaceHit, OutMantleInfo);
+	FVector LandingRootLocationForCheck = GroundHit.ImpactPoint;
+	LandingRootLocationForCheck.Z += 10.f; 
+	const FVector LandingCapsuleCenterForCheck = LandingRootLocationForCheck + FVector(0, 0, CapsuleHalfHeight);
+
+	if (!IsLandingSpaceClear(LandingCapsuleCenterForCheck))
+	{
+		if (bDrawDebug)
+		{
+			DrawDebugSphere(GetWorld(), LandingCapsuleCenterForCheck, CapsuleRadius, 16, FColor::Red, false, 2.f);
+		}
+		return false;
+	}
+
+	FVector FinalLandingRootLocation = GroundHit.ImpactPoint;
+	FinalLandingRootLocation.Z += FinalLandingHeightOffset;
+	
+	CalculateWarpTargets(FrontHit, SurfaceHit, FinalLandingRootLocation, OutMantleInfo);
 	
 	OutMantleInfo.LedgeLocation = SurfaceHit.ImpactPoint;
 	OutMantleInfo.TargetComponent = SurfaceHit.GetComponent();
 
-	const bool bDrawDebug = CVarDebugMantle.GetValueOnGameThread() > 0;
 	if (bDrawDebug)
 	{
 		DrawDebugSphere(GetWorld(), OutMantleInfo.UpWarpTarget.GetLocation(), 15.f, 16, FColor::Yellow, false, 5.f);
@@ -164,9 +227,8 @@ bool UTHParkourComponent::CheckMantle(FMantleInfo& OutMantleInfo) const
 	return true;
 }
 
-void UTHParkourComponent::CalculateWarpTargets(const FHitResult& FrontHit, const FHitResult& SurfaceHit, FMantleInfo& OutMantleInfo) const
+void UTHParkourComponent::CalculateWarpTargets(const FHitResult& FrontHit, const FHitResult& SurfaceHit, const FVector& FinalLandingLocation, FMantleInfo& OutMantleInfo) const
 {
-	const float CapsuleRadius = OwnerCharacter->GetCapsuleComponent()->GetScaledCapsuleRadius();
 	const FVector LedgeTopLocation = SurfaceHit.ImpactPoint;
 	
 	FVector MantleDirection = OwnerCharacter->GetActorForwardVector();
@@ -179,7 +241,5 @@ void UTHParkourComponent::CalculateWarpTargets(const FHitResult& FrontHit, const
 	UpTargetLocation.Z = LedgeTopLocation.Z + MantleUpZOffset;
 	OutMantleInfo.UpWarpTarget = FTransform(TargetRotation, UpTargetLocation);
 
-	FVector ForwardTargetLocation = LedgeTopLocation + (MantleDirection * (CapsuleRadius + MantleForwardOffset));
-	ForwardTargetLocation.Z += FinalLandingHeightOffset;
-	OutMantleInfo.ForwardWarpTarget = FTransform(TargetRotation, ForwardTargetLocation);
+	OutMantleInfo.ForwardWarpTarget = FTransform(TargetRotation, FinalLandingLocation);
 }

--- a/Source/TreasureHunter/ParkourComponent/THParkourComponent.h
+++ b/Source/TreasureHunter/ParkourComponent/THParkourComponent.h
@@ -54,7 +54,7 @@ protected:
 	float MaxMantleHeight = 200.f;
 
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Mantle Settings")
-	float MantleForwardOffset = 10.f;
+	float MantleForwardOffset = 25.f;
 	
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Mantle Settings")
 	float MantleUpZOffset = 3.f;
@@ -68,8 +68,8 @@ protected:
 private:
 	bool TraceForWall(FHitResult& OutFrontHit) const;
 	bool TraceForLedge(const FHitResult& FrontHit, FHitResult& OutSurfaceHit) const;
-	bool IsLandingSpaceClear(const FVector& LandingLocation, const FRotator& TargetRotation) const;
-	void CalculateWarpTargets(const FHitResult& FrontHit, const FHitResult& SurfaceHit, FMantleInfo& OutMantleInfo) const;
+	bool IsLandingSpaceClear(const FVector& LandingCapsuleCenter) const;
+	void CalculateWarpTargets(const FHitResult& FrontHit, const FHitResult& SurfaceHit, const FVector& FinalLandingLocation, FMantleInfo& OutMantleInfo) const;
 	
 	UPROPERTY(Transient)
 	TObjectPtr<ACharacter> OwnerCharacter;

--- a/Source/TreasureHunter/PlayerCharacter/THPlayerCharacter.h
+++ b/Source/TreasureHunter/PlayerCharacter/THPlayerCharacter.h
@@ -159,6 +159,12 @@ protected:
 	UPROPERTY(EditDefaultsOnly, Category = "Movement|Climb")
 	float MaxClimbSpeed = 150.f;
 
+	UPROPERTY(EditDefaultsOnly, Category = "Movement|Climb")
+	float ClimbingWallOffset = 5.f;
+
+	UPROPERTY(EditDefaultsOnly, Category = "Movement|Climb")
+	float ClimbingSlopeOffsetMultiplier = 15.f;
+
 public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	TObjectPtr<USpringArmComponent> SpringArm;


### PR DESCRIPTION
변경 사항 요약
감지 정확도와 효율성을 높이기 위해 SphereTraceSingle을 SphereTraceMulti 및 CapsuleTraceMultiForObjects로 교체했습니다.

더 정밀한 장애물 구분과 맨틀 표면 감지를 위해 TraceForWall 및 TraceForLedge 로직을 개선했습니다.

사용자 정의가 용이하도록 주요 트레이스 변수(반경 및 높이)를 ATHClimbComponent로 이동시켰습니다.

클라이밍 관련 위치 및 회전 조정 로직을 개선하여 캐릭터 이동 안정성을 강화했습니다.

맨틀링 및 착지 확인 시 중복 연산을 방지하기 위해 트레이스 유효성 검사 프로세스를 단순화했습니다.