### PR TITLE
클라이밍 이동 방향 초기화 로직 리팩터링

### DIFF
--- a/Source/TreasureHunter/PlayerCharacter/THPlayerCharacter.cpp
+++ b/Source/TreasureHunter/PlayerCharacter/THPlayerCharacter.cpp
@@ -160,6 +160,8 @@ void ATHPlayerCharacter::HandleMoveInput(const FInputActionValue& InValue)
 	if (THMovementComponent && THMovementComponent->IsClimbing())
 	{
 		const FVector2D MovementVector = InValue.Get<FVector2D>();
+		
+		this->ClimbMovementDirection = MovementVector; 
 		Server_SetClimbMovementDirection(MovementVector);
 
 		const FVector UpDirection = GetActorUpVector();
@@ -233,6 +235,7 @@ void ATHPlayerCharacter::OnMoveInputCompleted(const FInputActionValue& InValue)
 {
 	if (THMovementComponent && THMovementComponent->IsClimbing())
 	{
+		ClimbMovementDirection = FVector2D::ZeroVector;
 		Server_SetClimbMovementDirection(FVector2D::ZeroVector);
 	}
 }


### PR DESCRIPTION
ClimbMovementDirection의 상태를 더 효과적으로 관리하기 위해 초기화 로직을 추가했습니다.

ClimbMovementDirection 값이 InValue로부터 직접 반영되도록 처리 과정을 수정했습니다.

클라이밍 동작 이후 이동 방향을 초기화하는 로직을 추가했습니다.